### PR TITLE
fix in special cases service response with 400 - stop loop refresh

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,7 @@ export class SkeletonKey<USER_DATA = object, TOKEN_DATA = object> extends Eventi
       const {response} = ex;
       const {status} = response;
       // Forbidden / Unauthorized
-      if (status && status === 401 || status === 403)
+      if (status && status === 400 || status === 401 || status === 403)
         await this.logout();
     }
     return this.jwtBundle;


### PR DESCRIPTION
When renewType is interval and the service has any issue's with the request it could also answer with 400. Currently It loop endless - when status 400 leads to logout this should solve the issue.